### PR TITLE
test: refactored tests to not hardcode addresses

### DIFF
--- a/contracts/src/Raila.sol
+++ b/contracts/src/Raila.sol
@@ -222,8 +222,6 @@ contract Raila is IERC721, IERC721Metadata {
     }
 
     function forgiveDebt(uint256 requestId) external {
-        // todo this is equivalent to transferring the creditor status to debtor
-        // so migrate as internal function of Transfer => debtor?
         Request storage request = requests[requestId];
         require(
             request.status == RequestStatus.Loan


### PR DESCRIPTION
close #7

now when https://github.com/greenlucid/raila/issues/10 is complete tests should be way more reliable, right now i'm not fully trusting the `testFail` tests since i'm not checking for the specific errors, and anything that causes a revert will "succeed" the test.
i have probably missed some tests in the refactoring